### PR TITLE
Fix typos and ambiguities

### DIFF
--- a/latest/index.bs
+++ b/latest/index.bs
@@ -196,7 +196,7 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
         ├── .zgroup           # The tables group MAY be in root or in another group.
         |
         ├── .zattrs           # `.zattrs` MUST contain "tables", which lists the keys of the subgroups that are tables. In this case, the only table is "my_table".
-                              # hence `.zattrs` should be equal to `{ "tables": [ "my_table" ] }`.
+        │                     # hence `.zattrs` should be equal to `{ "tables": [ "my_table" ] }`.
         |
         └── my_table
             │                     # The table group MAY be in the root of the zarr file.
@@ -243,7 +243,7 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             │   └── col_0         # Each column in the obs table is a 1D zarr array. The rows can be chunked as the user desires.
             │       ├── .zarray   # However, the obs columns SHOULD be chunked in the same way as the rows in X (if present).
             │       │
-            │       └─ 0
+            │       └── 0
             ├── var               # You MAY add a var group container. The var group holds a table of annotations on the columns in X.
             |   │                 # The rows in var MUST be index-matched to the columns in X (if present). 
             |   |
@@ -255,33 +255,33 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             |   ├── array_col     # Columns in the var table MAY be a 1D zarr array. The rows can be chunked as the user desires.
             |   |   ├── .zarray   # However, the var columns SHOULD be chunked in the same way as the columns in X.
             |   |   │
-            |   |   └─ 0
+            |   |   └── 0
             |   |
-            |   └── cat_col       # Columns in the var table MAY be categorical
-            |       ├── .zattrs.  # `.zattrs` MUST contain `"encoding-type"`, which is set to `"categorical"` by AnnData.
-            |       |             # `.zattrs` MUST contain `"encoding-version"`, which is set to `"0.2.0"` by AnnData.
-            |       |
-            |       ├── categories
-            |       |  ├── .zarray # categories MUST be a 1D zarr array. The rows can be chunked as the user desires.
-            |       |  |
-            |       |  └─ 0
-            |       ├── codes
-            |       |  ├── .zarray # codes MUST be a 1D zarr array. The rows can be chunked as the user desires.
-            |       |  |
-            |       |  └─ 0
-            |       |
-            |       ├── null_col  # Columns in the var table MAY nullable integer
+            |   ├── cat_col       # Columns in the var table MAY be categorical
+            |   |   ├── .zattrs.  # `.zattrs` MUST contain `"encoding-type"`, which is set to `"categorical"` by AnnData.
+            |   |   |             # `.zattrs` MUST contain `"encoding-version"`, which is set to `"0.2.0"` by AnnData.
+            |   |   |
+            |   |   ├── categories
+            |   |   |   ├── .zarray  # categories MUST be a 1D zarr array. The rows can be chunked as the user desires.
+            |   |   |   |
+            |   |   |   └── 0
+            |   |   └── codes
+            |   |       ├── .zarray  # codes MUST be a 1D zarr array. The rows can be chunked as the user desires.
+            |   |       |
+            |   |       └── 0
+            |   |    
+            |   └── null_col      # Columns in the var table MAY nullable integer
             |       ├── .zattrs.  # `.zattrs` MUST contain `"encoding-type"`, which is set to `"nullable-integer"` by AnnData.
-            |       |             # `.zattrs` MUST contain `"encoding-version"`, which is set to `"0.1.0"` by AnnData.
-            |       |
+            |       │             # `.zattrs` MUST contain `"encoding-version"`, which is set to `"0.1.0"` by AnnData.
+            |       │
             |       ├── mask
-            |       |  ├── .zarray # categories MUST be a 1D zarr array. The rows can be chunked as the user desires.
-            |       |  |
-            |       |  └─ 0
+            |       │   ├── .zarray  # categories MUST be a 1D zarr array. The rows can be chunked as the user desires.
+            |       │   │
+            |       │   └── 0
             |       └── values
-            |          ├── .zarray # codes MUST be a 1D zarr array. The rows can be chunked as the user desires.
-            |          |
-            |          └─ 0
+            |           ├── .zarray  # codes MUST be a 1D zarr array. The rows can be chunked as the user desires.
+            |           │
+            |           └── 0
             |
             ├── obsm              # You MAY add a obsm group container. The obsm group contains arrays that annotate the rows in X.
             |   │                 # The rows in each array MUST be index-matched to the rows in X (if present). 
@@ -431,7 +431,7 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
                 |   └── col_0         # Each column in the obs table is a 1D zarr array.
                 |       ├── .zarray   # Each columns MUST be chunked the same, but the chunking may be chosen by the user.
                 |       │
-                |       └─ 0
+                |       └── 0
                 |
                 ├── dense_array       # You MAY add dense arrays as n n-dimensional zarr arrays.
                 |   │                 # `dense_array` MUST not be a complex type (i.e., MUST be a single type)

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -240,8 +240,8 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             │   │                 # `.zattrs` MUST contain `"encoding-type"`, which is set to `"dataframe"` by AnnData.
             │   │                 # `.zattrs` MUST contain `"encoding-version"`, which is set to `"0.2.0"` by AnnData.
             │   │      
-            │   └── col_0         # Each column in the obs table is a 1D zarr array. The rows can be chunked as the user desires.
-            │       ├── .zarray   # However, the obs columns SHOULD be chunked in the same way as the rows in X (if present).
+            │   └── col_0         # Each column in the obs table is a 1D zarr array. The columns can be chunked as the user desires.
+            │       ├── .zarray   # However, the obs columns SHOULD be chunked in the same way as the rows of X (if present).
             │       │
             │       └── 0
             ├── var               # You MAY add a var group container. The var group holds a table of annotations on the columns in X.
@@ -252,8 +252,8 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             |   │                 # `.zattrs` MUST contain `"encoding-type"`, which is set to `"dataframe"` by AnnData.
             |   │                 # `.zattrs` MUST contain `"encoding-version"`, which is set to `"0.2.0"` by AnnData.
             |   │
-            |   ├── array_col     # Columns in the var table MAY be a 1D zarr array. The rows can be chunked as the user desires.
-            |   |   ├── .zarray   # However, the var columns SHOULD be chunked in the same way as the columns in X.
+            |   ├── array_col     # Columns in the var table MAY be a 1D zarr array. The columns can be chunked as the user desires.
+            |   |   ├── .zarray   # However, the var columns SHOULD be chunked in the same way as the columns of X (if present).
             |   |   │
             |   |   └── 0
             |   |
@@ -262,12 +262,12 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             |   |   |             # `.zattrs` MUST contain `"encoding-version"`, which is set to `"0.2.0"` by AnnData.
             |   |   |
             |   |   ├── categories
-            |   |   |   ├── .zarray  # categories MUST be a 1D zarr array. The rows can be chunked as the user desires.
+            |   |   |   ├── .zarray  # categories MUST be a 1D zarr array, which can be chunked as the user desires.
             |   |   |   |
             |   |   |   └── 0
             |   |   └── codes
-            |   |       ├── .zarray  # codes MUST be a 1D zarr array. The rows can be chunked as the user desires.
-            |   |       |
+            |   |       ├── .zarray  # codes MUST be a 1D zarr array, which can be chunked as the user desires.
+            |   |       |            # However, the codes SHOULD be chunked in the same way as the columns of X (if present).
             |   |       └── 0
             |   |    
             |   └── null_col      # Columns in the var table MAY nullable integer
@@ -275,12 +275,12 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             |       │             # `.zattrs` MUST contain `"encoding-version"`, which is set to `"0.1.0"` by AnnData.
             |       │
             |       ├── mask
-            |       │   ├── .zarray  # categories MUST be a 1D zarr array. The rows can be chunked as the user desires.
-            |       │   │
+            |       │   ├── .zarray  # categories MUST be a 1D zarr array, which can be chunked as the user desires.
+            |       │   │            # However, the mask SHOULD be chunked in the same way as the columns of X (if present).
             |       │   └── 0
             |       └── values
             |           ├── .zarray  # codes MUST be a 1D zarr array. The rows can be chunked as the user desires.
-            |           │
+            |           │            # However, the values SHOULD be chunked in the same way as the columns of X (if present).
             |           └── 0
             |
             ├── obsm              # You MAY add a obsm group container. The obsm group contains arrays that annotate the rows in X.
@@ -345,7 +345,7 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             │       |   └── n
             |       |
             |       ├── indices   # You MUST add a one-dimensional zarr array named "indices".
-            |       |   |         # `indices` MAY be chunked as the user desires.
+            |       |   |         # `indices` MAY be chunked as the user desires but SHOULD be chunked the same as `data`.
             |       |   ├── .zarray  # `indices` MUST be an `int` dtype.
             |       |   |
             |       |   ├── 0
@@ -387,7 +387,7 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             │       |   └── n
             |       |
             |       ├── indices   # You MUST add a one-dimensional zarr array named "indices".
-            |       |   |         # `indices` MAY be chunked as the user desires.
+            |       |   |         # `indices` MAY be chunked as the user desires but SHOULD be chunked the same as `data`.
             |       |   ├── .zarray  # `indices` MUST be an `int` dtype.
             |       |   |
             |       |   ├── 0
@@ -428,8 +428,8 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
                 |   │                 # `.zattrs` MUST contain `"encoding-type"`, which is set to `"dataframe"` by AnnData.
                 |   │                 # `.zattrs` MUST contain `"encoding-version"`, which is set to `"0.2.0"` by AnnData.
                 |   │      
-                |   └── col_0         # Each column in the obs table is a 1D zarr array.
-                |       ├── .zarray   # Each columns MUST be chunked the same, but the chunking may be chosen by the user.
+                |   └── col_0         # Each column in the table is a 1D zarr array.
+                |       ├── .zarray   # Each column MUST be chunked the same, but the chunking may be chosen by the user.
                 |       │
                 |       └── 0
                 |
@@ -461,7 +461,7 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
                     |   └── n
                     |
                     ├── indices      # You MUST add a one-dimensional zarr array named "indices".
-                    |   |            # `indices` MAY be chunked as the user desires.
+                    |   |            # `indices` MAY be chunked as the user desires but SHOULD be chunked the same as `data`.
                     |   ├── .zarray  # `indices` MUST be an `int` dtype.
                     |   |
                     |   ├── 0

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -240,7 +240,7 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             │   │                 # `.zattrs` MUST contain `"encoding-type"`, which is set to `"dataframe"` by AnnData.
             │   │                 # `.zattrs` MUST contain `"encoding-version"`, which is set to `"0.2.0"` by AnnData.
             │   │      
-            │   └── col_0         # Each column in the obs table is a 1D zarr array. The columns can be chunked as the user desires.
+            │   └── col_0         # Each column in the obs table is a 1D zarr array and can be chunked as the user desires.
             │       ├── .zarray   # However, the obs columns SHOULD be chunked in the same way as the rows of X (if present).
             │       │
             │       └── 0
@@ -252,7 +252,7 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             |   │                 # `.zattrs` MUST contain `"encoding-type"`, which is set to `"dataframe"` by AnnData.
             |   │                 # `.zattrs` MUST contain `"encoding-version"`, which is set to `"0.2.0"` by AnnData.
             |   │
-            |   ├── array_col     # Columns in the var table MAY be a 1D zarr array. The columns can be chunked as the user desires.
+            |   ├── array_col     # Columns in the var table MAY be a 1D zarr array and can be chunked as the user desires.
             |   |   ├── .zarray   # However, the var columns SHOULD be chunked in the same way as the columns of X (if present).
             |   |   │
             |   |   └── 0
@@ -262,24 +262,24 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             |   |   |             # `.zattrs` MUST contain `"encoding-version"`, which is set to `"0.2.0"` by AnnData.
             |   |   |
             |   |   ├── categories
-            |   |   |   ├── .zarray  # categories MUST be a 1D zarr array, which can be chunked as the user desires.
+            |   |   |   ├── .zarray  # categories MUST be a 1D zarr array and can be chunked as the user desires.
             |   |   |   |
             |   |   |   └── 0
             |   |   └── codes
-            |   |       ├── .zarray  # codes MUST be a 1D zarr array, which can be chunked as the user desires.
+            |   |       ├── .zarray  # codes MUST be a 1D zarr array and can be chunked as the user desires.
             |   |       |            # However, the codes SHOULD be chunked in the same way as the columns of X (if present).
             |   |       └── 0
             |   |    
-            |   └── null_col      # Columns in the var table MAY nullable integer
+            |   └── null_col      # Columns in the var table MAY be nullable integers
             |       ├── .zattrs.  # `.zattrs` MUST contain `"encoding-type"`, which is set to `"nullable-integer"` by AnnData.
             |       │             # `.zattrs` MUST contain `"encoding-version"`, which is set to `"0.1.0"` by AnnData.
             |       │
             |       ├── mask
-            |       │   ├── .zarray  # categories MUST be a 1D zarr array, which can be chunked as the user desires.
+            |       │   ├── .zarray  # categories MUST be a 1D zarr array and can be chunked as the user desires.
             |       │   │            # However, the mask SHOULD be chunked in the same way as the columns of X (if present).
             |       │   └── 0
             |       └── values
-            |           ├── .zarray  # codes MUST be a 1D zarr array. The rows can be chunked as the user desires.
+            |           ├── .zarray  # codes MUST be a 1D zarr array and can be chunked as the user desires.
             |           │            # However, the values SHOULD be chunked in the same way as the columns of X (if present).
             |           └── 0
             |

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -209,7 +209,7 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             |                     # `.zattrs` MUST contain "region_key" if "region" is an array. "region_key" is the key in `obs` denoting which region a given row corresponds to.
             |                     # `.zattrs` MAY contain "instance_key", which is the key in `obs` that denotes which instance in "region" the row corresponds to. If "instance_key" is not provided, the values from the `obs` `.zattrs` "_index" key is used.
             │
-            ├── X                 # You MAY add an zarr array `X`.
+            ├── X                 # You MAY add a zarr array `X`.
             │   │                 # `X` MUST not be a complex type (i.e., MUST be a single type)
             │   │                 # `X` MAY be chunked as the user desires.
             │   ├── .zarray
@@ -283,7 +283,7 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             |          |
             |          └─ 0
             |
-            ├── obsm              # You MAY add a obsm group comtainer. The obsm group contains arrays that annotate the rows in X.
+            ├── obsm              # You MAY add a obsm group container. The obsm group contains arrays that annotate the rows in X.
             |   │                 # The rows in each array MUST be index-matched to the rows in X (if present). 
             |   |
             │   ├── .zgroup
@@ -301,7 +301,7 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             │       │   ...
             │       └── n.m
             |
-            ├── varm              # You MAY add a varm group comtainer. The varm group contains arrays that annotate the columns in X.
+            ├── varm              # You MAY add a varm group container. The varm group contains arrays that annotate the columns in X.
             |   │                 # The rows in each array MUST be index-matched to the columns in X (if present). 
             |   |
             │   ├── .zgroup
@@ -318,7 +318,7 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             │       │   ...
             │       └── n.m
             |
-            ├── obsp              # You MAY add a obsp group comtainer. The obsp group contains sparse arrays that annotate the rows in X.
+            ├── obsp              # You MAY add a obsp group container. The obsp group contains sparse arrays that annotate the rows in X.
             |   │                 # The rows in each array MUST be index-matched to the columns in X (if present). 
             |   |
             │   ├── .zgroup
@@ -360,7 +360,7 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             │           |   ...
             │           └── n
             |
-            ├── varp              # You MAY add a varp group comtainer. The varp group contains sparse arrays that annotate the columns in X.
+            ├── varp              # You MAY add a varp group container. The varp group contains sparse arrays that annotate the columns in X.
             |   │                 # The rows in each array MUST be index-matched to the columns in X (if present). 
             |   |
             │   ├── .zgroup
@@ -402,7 +402,7 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
             │           |   ...
             │           └── n
             |
-            └── uns               # You MAY add a uns containter to store unstructured data.
+            └── uns               # You MAY add an uns container to store unstructured data.
                 |
                 ├── .zgroup
                 |
@@ -433,7 +433,7 @@ OME-NGFF tables are compatible with the [AnnData model](https://github.com/scver
                 |       │
                 |       └─ 0
                 |
-                ├── dense_array       # You MAY dense arrays as n n-dimensional zarr arrays.
+                ├── dense_array       # You MAY add dense arrays as n n-dimensional zarr arrays.
                 |   │                 # `dense_array` MUST not be a complex type (i.e., MUST be a single type)
                 |   │                 # `dense_array` MAY be chunked as the user desires.
                 |   |                 # `dense array` MAY be in the `uns` group or in a subgroup.


### PR DESCRIPTION
Hi Kevin, thanks for putting together this addition to the OME-NGFF spec!

I've been reading the table spec very carefully lately and came across some minor typos and (perceived) ambiguities. Therefore, I suggest a few changes that hopefully contribute to the spec being more precise and complete:

* Nullable integers seemed to be at the wrong hierarchy level within the `var` group, so I put them one level higher.
* The wording of the chunking recommendations for columns in the `obs` and `var` dataframes seemed ambiguous to me. I tried to make it as clear as possible and consistent with `obsm` and `varm`.
* I added some recommendations for chunking of arrays within non-basic dataframe columns (nullable integers and categoricals) as well as for sparse arrays. The rationale behind my changes is that arrays that are likely to be read together should ideally share chunk sizes (which was your original intention, I believe). In particular:
  * the `codes`, `mask` and `values` array should be chunked the same way as the corresponding dimension of `X`;
  * the `data` and `indices` arrays of sparse matrices should be chunked in the same way.


Furthermore, I am confused by the absence of nullable integers and categoricals in the `obs` group. In my understanding, `obs` and `var` should be qualitatively the same, but associated with different dimensions of `X`, is this correct?
If this absence is unintentional, I suggest to add nullable integers and categoricals also to `obs` and I'd be happy to do so.